### PR TITLE
Emulate APIv2 call for playlist_items

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.youtube" name="YouTube" version="5.0.1" provider-name="bromix">
+<addon id="plugin.video.youtube" name="YouTube" version="5.0.2" provider-name="bromix">
 	<requires>
 		<import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.requests" version="2.3.0"/>

--- a/resources/lib/youtube/client/youtube.py
+++ b/resources/lib/youtube/client/youtube.py
@@ -267,7 +267,6 @@ class YouTube(LoginClient):
                   'playlistId': playlist_id}
         if page_token:
             params['pageToken'] = page_token
-            pass
 
         return self._perform_v3_request(method='GET', path='playlistItems', params=params)
 


### PR DESCRIPTION
Start playlist from video_id passed as argument.

Allow "/play/?playlist_id=XXXX&video_id=YYYYY" as URI, to match old plugin functionality. 
