### PR TITLE
[fix] set studio + artist infolabel based on channel name

### DIFF
--- a/resources/lib/youtube/helper/utils.py
+++ b/resources/lib/youtube/helper/utils.py
@@ -67,10 +67,10 @@ def update_video_infos(provider, context, video_id_dict, playlist_item_id_dict=N
         description = kodion.utils.strip_html_from_text(snippet['description'])
         if channel_name and settings.get_bool('youtube.view.description.show_channel_name', True):
             description = '[UPPERCASE][B]%s[/B][/UPPERCASE][CR][CR]%s' % (channel_name, description)
-            video_item.set_studio(channel_name)
-            # video_item.add_cast(channel_name)
-            video_item.add_artist(channel_name)
             pass
+        video_item.set_studio(channel_name)
+        # video_item.add_cast(channel_name)
+        video_item.add_artist(channel_name)
         video_item.set_plot(description)
 
         # date time


### PR DESCRIPTION
doesn't depend whether or not the option to add it to the description is enabled.