### PR TITLE
Add Jarvis version awareness.

### DIFF
--- a/resources/lib/kodion/impl/xbmc/xbmc_system_version.py
+++ b/resources/lib/kodion/impl/xbmc/xbmc_system_version.py
@@ -34,5 +34,8 @@ class XbmcSystemVersion(AbstractSystemVersion):
         if self._version >= (15, 0):
             self._name = 'Isengard'
             pass
+        if self._version >= (16, 0):
+            self._name = 'Jarvis'
+            pass
 
     pass

--- a/resources/lib/youtube/client/login_client.py
+++ b/resources/lib/youtube/client/login_client.py
@@ -55,7 +55,7 @@ class LoginClient(object):
             'secret': '_BEENv-a3-egDz_QKo5pGZCK'
         },
         'youtube-for-kodi-16': {
-            'system': 'J...',
+            'system': 'Jarvis',
             'key': 'AIzaSyBbgC4PZ2_hUdqqX7MIgdg2fK1nohv1jrw',
             'id': '17932591024-8jruv1v7s78gipo7s17c91bnk26rqgpf.apps.googleusercontent.com',
             'secret': 'bK9T234WWhqzYdcQLif1L35K'


### PR DESCRIPTION
Hi bromix,
This just adds Jarvis as a proper version...  I only noticed this when I would see the addon log messages as "Isengard" on my Jarvis test setup. Take care.